### PR TITLE
Create use-pipe-in-one-line-command.markdown

### DIFF
--- a/_tips/use-pipe-in-one-line-command.markdown
+++ b/_tips/use-pipe-in-one-line-command.markdown
@@ -4,7 +4,7 @@ title:  "Piping inside WSL when using Powershell"
 date:   2020-08-13
 categories: powershell, oneliner, piping
 author: Nuno Captain Corsair
-author-twitter: @nunixtech
+author-twitter: nunixtech
 author-github: nunix
 author-website: https://wsl.dev
 ---

--- a/_tips/use-pipe-in-one-line-command.markdown
+++ b/_tips/use-pipe-in-one-line-command.markdown
@@ -1,0 +1,18 @@
+---
+layout: post
+title:  "Piping inside WSL when using Powershell"
+date:   2020-08-13
+categories: powershell, oneliner, piping
+author: Nuno Captain Corsair
+author-twitter: @nunixtech
+author-github: nunix
+author-website: https://wsl.dev
+---
+
+When running a `wsl.exe` command in Powershell, it can be needed/useful to pipe the output *inside* the WSL shell instead of Powershell (see [Run commands across WSL distros](https://craigloewen-msft.github.io/WSLTipsAndTricks/tip/multi-distro-commands.html)
+In order to achieve that, we need to use the `wsl.exe --` instead of `wsl.exe --exec` command as we need the WSL shell to be spawned (which `--exec` doesn't do).
+Finally, we also need to "escape" the pipe character so it's not interpreted by Powershell:
+
+```bash
+wsl.exe -- cat /etc/hosts `| grep localhost
+``` 


### PR DESCRIPTION
created the tip on how to use the pipe symbol inside WSL when run as a command form Powershell